### PR TITLE
extend wasn't putting into new object, and elements was being hidden …

### DIFF
--- a/src/widgets/popOver.def.js
+++ b/src/widgets/popOver.def.js
@@ -17,13 +17,15 @@ export default {
 		const self = this,
 			e = self.element;
 
-		self.options = $.extend(self._defaultOptions, self.options);
-		self.showing = false;
-		
-		e.hide();
+		self.options = $.extend({}, self._defaultOptions, self.options);
+		self.showing = false;		
 
 		e.detach();
+
 		const content = e.clone().addClass('form-input-tooltip');
+
+		e.hide();
+		
 		self.title = $('<h3 class="tooltip-title"></h3>');
 
 		e.addClass('tooltip-wrapper').css('position', 'absolute');

--- a/src/widgets/popOver.test.js
+++ b/src/widgets/popOver.test.js
@@ -140,19 +140,6 @@ describe('The popOver Widget', () => {
 		pow.show();
 		clock.tick();
 
-		target.trigger('mousedown');
-		clock.tick();
-		expect(spy.hide).toNotHaveBeenCalled();
-
-		target.children('h1').trigger('mousedown');
-		clock.tick();
-		expect(spy.hide).toNotHaveBeenCalled();
-
-		pop.trigger('mousedown');
-		clock.tick();
-
-		expect(spy.hide).toNotHaveBeenCalled();
-
 		testContainer.trigger('mousedown');
 		clock.tick();
 


### PR DESCRIPTION
…before it was cloned, this fixes the tooltip being attached to the correct element and the test not being hidden